### PR TITLE
Pthread server read

### DIFF
--- a/serialize/request.c
+++ b/serialize/request.c
@@ -339,7 +339,6 @@ socket_t *get_socket(char *HOST, char *PORT) {
 	hints.ai_socktype = SOCK_STREAM;  // TCP stream sockets
 	hints.ai_flags = AI_PASSIVE;	  // fill in my IP for me
 
-	printf("%s %s\n", HOST, PORT);
 	if ((status = getaddrinfo(HOST, PORT, &hints, &servinfo)) != 0) {
 		fprintf(stderr, "getaddrinfo error: %s\n", gai_strerror(status));
 		exit(1);

--- a/serialize/request.c
+++ b/serialize/request.c
@@ -377,6 +377,8 @@ socket_t *get_socket(char *HOST, char *PORT) {
 }
 
 int destroy_socket(socket_t *socket_data) {
+	if (!socket_data->servinfo)
+		return 0;
 	freeaddrinfo((struct addrinfo *) socket_data->servinfo);
 
 	free(socket_data);

--- a/serialize/request.h
+++ b/serialize/request.h
@@ -16,6 +16,10 @@ typedef struct SocketData {
 	char *HOST, *PORT;
 } socket_t;
 
+struct MutexPtr {
+	pthread_mutex_t mutex;
+};
+
 socket_t *get_socket(char *HOST, char *PORT);
 int destroy_socket(socket_t *socket_data);
 

--- a/serialize/request.h
+++ b/serialize/request.h
@@ -19,7 +19,7 @@ typedef struct SocketData {
 socket_t *get_socket(char *HOST, char *PORT);
 int destroy_socket(socket_t *socket_data);
 
-res *send_req(mutex_t sock, char *sub_url, char *type, char *param, ...);
+res *send_req(socket_t *sock, char *sub_url, char *type, char *param, ...);
 
 // res is the response body, max_len is the length of the
 // char ** returned. So an input of:

--- a/serialize/request.h
+++ b/serialize/request.h
@@ -2,6 +2,7 @@
 #define __SOCKET_L__
 
 #include "hashmap.h"
+#include "serialize.h"
 
 typedef struct Response res;
 char *res_body(res *re);
@@ -18,7 +19,7 @@ typedef struct SocketData {
 socket_t *get_socket(char *HOST, char *PORT);
 int destroy_socket(socket_t *socket_data);
 
-res *send_req(socket_t *sock, char *sub_url, char *type, char *param, ...);
+res *send_req(mutex_t sock, char *sub_url, char *type, char *param, ...);
 
 // res is the response body, max_len is the length of the
 // char ** returned. So an input of:

--- a/serialize/serialize.c
+++ b/serialize/serialize.c
@@ -405,6 +405,7 @@ hashmap_body_t **word_bag_idf(FILE *index_reader, hashmap *idf, int *word_bag_le
 		new_map->map = make__hashmap(0, NULL, destroy_hashmap_float);
 
 		// for each word:freq pair:
+		printf("%d\n", *word_bag_words_max);
 		for (int check_doc = 2; check_doc < *word_bag_words_max; check_doc += 2) {
 			hashmap__response *word_dtf = get__hashmap(idf, word_bag_words[check_doc], 1);
 			free(word_bag_words[check_doc]);

--- a/serialize/serialize.c
+++ b/serialize/serialize.c
@@ -198,10 +198,12 @@ int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t 
 	char *title = token_read_all_data(grab_token_by_tag(full_page, "title"), title_len, NULL, NULL);
 
 	// write to title_fp
-	fputs(*ID, title_fp);
-	fputs(":", title_fp);
-	fputs(title, title_fp);
-	fputs("\n", title_fp);
+	pthread_mutex_lock(&(index_fp->mutex));
+	fputs(*ID, index_fp->runner);
+	fputs(":", index_fp->runner);
+	fputs(title, index_fp->runner);
+	fputs("\n", index_fp->runner);
+	pthread_mutex_unlock(&(index_fp->mutex));
 
 	free(title_len);
 	free(title);
@@ -253,10 +255,12 @@ int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t 
 
 		// get from word_freq_hash:
 		// get char * from idf and free full_page_data
-		char *freq_key = getKey__hashmap(idf_hash, full_page_data[add_hash]);
+		char *freq_key = getKey__hashmap(idf_hash->runner, full_page_data[add_hash]);
 		int *hashmap_freq = get__hashmap(word_freq_hash, full_page_data[add_hash], 0);
 		idf_t *idf;
-		idf = freq_key ? get__hashmap(idf_hash, full_page_data[add_hash], 0) : NULL;
+		idf = freq_key ? get__hashmap(idf_hash->runner, full_page_data[add_hash], 0) : NULL;
+
+		pthread_mutex_lock()
 
 		if (hashmap_freq) {
 			free(full_page_data[add_hash]);
@@ -271,6 +275,8 @@ int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t 
 
 		insert__hashmap(word_freq_hash, freq_key ? freq_key : full_page_data[add_hash], hashmap_freq, "", compareCharKey, NULL);
 		// check prev_idf_ID to make sure it doesn't match current index
+		pthread_mutex_lock(&(idf_hash->mutex));
+
 		if (idf && strcmp(idf->prev_idf_ID, *ID) == 0) { // skip (duplicate)
 			continue;
 		} else if (idf) { // add to current frequency
@@ -283,6 +289,8 @@ int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t 
 			insert__hashmap(idf_hash, freq_key ? freq_key : full_page_data[add_hash], idf, "", compareCharKey, destroyCharKey);
 		}
 
+		pthread_mutex_unlock(&(idf_hash->mutex));
+
 		if (freq_key)
 			free(full_page_data[add_hash]);
 	}
@@ -294,7 +302,10 @@ int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t 
 	char **keys = (char **) keys__hashmap(word_freq_hash, key_len);
 
 	// setup index file:
-	int check = fputs(*ID, index_fp);
+	pthread_mutex_lock(&(index_fp->mutex));
+	int check = fputs(*ID, index_fp->runner);
+	pthread_mutex_unlock(&(index_fp->mutex)); // close to allow others to use
+		// while calculating sum of squares (slow)
 
 	if (check == -1) return -1;
 
@@ -307,7 +318,8 @@ int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t 
 
 	sprintf(sum_square_char, " %d ", sum_of_squares);
 	total_bag_size += strlen(sum_square_char);
-	check = fputs(sum_square_char, index_fp);
+	pthread_mutex_lock(&(index_fp->mutex));
+	check = fputs(sum_square_char, index_fp->runner);
 
 	if (check == -1) return -1;
 
@@ -325,16 +337,17 @@ int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t 
 		// add length of key_freq_str to bag_size:
 		total_bag_size += strlen(key_freq_str);
 
-		check = fputs(keys[write_key], index_fp);
+		check = fputs(keys[write_key], index_fp->runner);
 		if (check == -1) return -1;
-		check = fputs(key_freq_str, index_fp);
+		check = fputs(key_freq_str, index_fp->runner);
 		if (check == -1) return -1;
 
 		free(key_freq_str);
 	}
 
-	fputs("\n", index_fp);
+	fputs("\n", index_fp->runner);
 	total_bag_size++;
+	pthread_mutex_unlock(&(index_fp->mutex));
 
 	free(keys);
 	free(key_len);

--- a/serialize/serialize.c
+++ b/serialize/serialize.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <pthread.h>
 
 #include "serialize.h"
 #include "../stemmer.h"
@@ -177,7 +178,11 @@ void *is_block(void *hmap, char *tag) {
 	return get__hashmap((hashmap *) hmap, tag, 0);
 }
 
-int word_bag(FILE *index_fp, FILE *title_fp, trie_t *stopword_trie, token_t *full_page, hashmap *idf_hash, char **ID) {
+/* Update to wordbag:
+	Now index_fp, title_fp, and idf_hash need mutex locking,
+	so bring mutex attr with them
+*/
+int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t *full_page, mutex_t idf_hash, char **ID) {
 	int total_bag_size = 0;
 
 	// create title page:

--- a/serialize/serialize.c
+++ b/serialize/serialize.c
@@ -394,6 +394,7 @@ hashmap_body_t **word_bag_idf(FILE *index_reader, hashmap *idf, int *word_bag_le
 		int *word_bag_words_max = malloc(sizeof(int));
 		char **word_bag_words = split_string(word_bag, 0, word_bag_words_max, "-d-r", delimeter_check, " :", num_is_range);
 
+		printf("%s: %d\n", word_bag_words[0], word_bag_len[doc_index] + 1);
 		free(word_bag);
 
 		hashmap_body_t *new_map = malloc(sizeof(hashmap_body_t));
@@ -405,7 +406,7 @@ hashmap_body_t **word_bag_idf(FILE *index_reader, hashmap *idf, int *word_bag_le
 		new_map->map = make__hashmap(0, NULL, destroy_hashmap_float);
 
 		// for each word:freq pair:
-		printf("%d\n", *word_bag_words_max);
+		printf("%s %s %d\n", new_map->id, word_bag_words[*word_bag_words_max - 1], *word_bag_words_max);
 		for (int check_doc = 2; check_doc < *word_bag_words_max; check_doc += 2) {
 			hashmap__response *word_dtf = get__hashmap(idf, word_bag_words[check_doc], 1);
 			free(word_bag_words[check_doc]);

--- a/serialize/serialize.c
+++ b/serialize/serialize.c
@@ -204,12 +204,12 @@ int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t 
 	char *title = token_read_all_data(grab_token_by_tag(full_page, "title"), title_len, NULL, NULL);
 
 	// write to title_fp
-	pthread_mutex_lock(&index_fp.mutex);
-	fputs(*ID, index_fp.runner);
-	fputs(":", index_fp.runner);
-	fputs(title, index_fp.runner);
-	fputs("\n", index_fp.runner);
-	pthread_mutex_unlock(&index_fp.mutex);
+	pthread_mutex_lock(&title_fp.mutex);
+	fputs(*ID, title_fp.runner);
+	fputs(":", title_fp.runner);
+	fputs(title, title_fp.runner);
+	fputs("\n", title_fp.runner);
+	pthread_mutex_unlock(&title_fp.mutex);
 
 	free(title_len);
 	free(title);
@@ -308,8 +308,6 @@ int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t 
 	// setup index file:
 	pthread_mutex_lock(&index_fp.mutex);
 	int check = fputs(*ID, index_fp.runner);
-	pthread_mutex_unlock(&index_fp.mutex); // close to allow others to use
-		// while calculating sum of squares (slow)
 
 	if (check == -1) return -1;
 
@@ -322,7 +320,6 @@ int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t 
 
 	sprintf(sum_square_char, " %d ", sum_of_squares);
 	total_bag_size += strlen(sum_square_char);
-	pthread_mutex_lock(&index_fp.mutex);
 	check = fputs(sum_square_char, index_fp.runner);
 
 	if (check == -1) return -1;

--- a/serialize/serialize.h
+++ b/serialize/serialize.h
@@ -15,7 +15,7 @@ typedef struct MutexLocker {
 } mutex_t;
 mutex_t newMutexLocker(void *payload);
 
-int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t *full_page, mutex_t idf, char **ID);
+int word_bag(mutex_t *index_fp, mutex_t *title_fp, trie_t *stopword_trie, token_t *full_page, mutex_t *idf, char **ID);
 
 typedef struct HashmapBody {
 	char *id;

--- a/serialize/serialize.h
+++ b/serialize/serialize.h
@@ -8,13 +8,20 @@
 typedef struct IDF_Track idf_t;
 void hashmap_destroy_idf(void *p);
 
-int word_bag(FILE *index_fp, FILE *title_fp, trie_t *stopword_trie, token_t *full_page, hashmap *idf, char **ID);
+// struct for mutex locking
+typedef struct MutexLocker {
+	pthread_mutex_t mutex;
+	void *runner;
+} mutex_t;
+
+int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t *full_page, mutex_t idf, char **ID);
 
 typedef struct HashmapBody {
 	char *id;
 	float mag, sqrt_mag;
 	hashmap *map;
 } hashmap_body_t;
+
 void destroy_hashmap_body(hashmap_body_t *body_hash);
 hashmap_body_t **word_bag_idf(FILE *index_reader, hashmap *idf, int *word_bag_len, int word_bag_len_max, int dtf_drop_threshold);
 

--- a/serialize/serialize.h
+++ b/serialize/serialize.h
@@ -13,6 +13,7 @@ typedef struct MutexLocker {
 	pthread_mutex_t mutex;
 	void *runner;
 } mutex_t;
+mutex_t newMutexLocker(void *payload);
 
 int word_bag(mutex_t index_fp, mutex_t title_fp, trie_t *stopword_trie, token_t *full_page, mutex_t idf, char **ID);
 

--- a/serialize/title.txt
+++ b/serialize/title.txt
@@ -24,3 +24,60 @@
 25:Virginia Cavaliers men's basketball
 26:Virginia Cavaliers
 27:Apple Inc.
+28:Cyclone Batsirai
+29:Wikipedia
+30:Horizon
+31:Seam carving
+32:-means clusteringk 
+33:Fred Hampton
+34:Roman Empire
+35:Augustus
+36:Assassination of Julius Caesar
+37:Julius Caesar
+38:Crossing the Rubicon
+39:René Magritte
+40:Barbary Wars
+41:Gustav IV Adolf
+42:Gustav III
+43:Wikipedia:About
+44: (video game)Rust 
+45:EOKA
+46:McNab
+47:Clan Macnab
+48:Palmer Raids
+49: (film)Reds 
+50:Communist Labor Party of America
+51:Communist Party USA
+52:Socialist Party of America
+53:Social Democrats, USA
+54:Democratic Socialists of America
+55:Siege of Vicksburg
+56:Farmer–Labor Party
+57:Populism
+58:Communism
+59:2020 United States presidential election
+60:Democratic Party (United States)
+61:Nationwide opinion polling for the 2020 United States presidential election
+62:Jo Jorgensen
+63:Libertyville, Illinois
+64:William Jennings Bryan
+65:1896 United States presidential election
+66:1900 United States presidential election
+67:1904 United States presidential election
+68:1908 United States presidential election
+69:People's Party (United States)
+70:Garret Hobart
+71:Thomas E. Watson
+72:Charlottesville, Virginia
+73:Battle of Rio Hill
+74:Ukraine
+75:Revolution of Dignity
+76: (magazine)Documents 
+77: (film)Detachment 
+78:Partition of a set
+79:C data types
+80:Russo-Ukrainian War
+81:C standard library
+82:C
+83:Islamic Emirate of Afghanistan (1996–2001)
+84:Islamic State of Afghanistan

--- a/serialize/token.c
+++ b/serialize/token.c
@@ -324,7 +324,7 @@ int read_newline(char **curr_line, size_t *buffer_size, FILE *fp, char *str_read
 		str_read_index++;
 
 		// check for resize
-		if ((str_read_index) * sizeof(char) == *buffer_size) {
+		if ((str_read_index + 1) * sizeof(char) == *buffer_size) {
 			// increase
 			*buffer_size *= 2;
 			*curr_line = realloc(*curr_line, *buffer_size);

--- a/serialize/vecrep.c
+++ b/serialize/vecrep.c
@@ -11,11 +11,11 @@
 #include "hashmap.h"
 #include "serialize.h"
 
-#define HOST "cutewiki.charlie.city"
-#define PORT "8822"
+#define HOST getenv("WIKIREAD_HOST")
+#define PORT getenv("WIKIREAD_PORT")
 
-#define REQ_NAME "permission_data_pull"
-#define REQ_PASSCODE "d6bc639b-8235-4c0d-82ff-707f9d47a4ca"
+#define REQ_NAME getenv("WIKIREAD_REQ_NAME")
+#define REQ_PASSCODE getenv("WIKIREAD_REQ_PASSCODE")
 
 #define THREAD_NUMBER 8
 
@@ -109,7 +109,7 @@ int main() {
 	hashmap *idf = make__hashmap(0, NULL, hashmap_destroy_idf);
 
 	// initial header request
-	res *response = send_req(sock_data, "/pull_page_names", "GET", "-q", "?name=$&passcode=$", REQ_NAME, REQ_PASSCODE);
+	res *response = send_req(sock_data, "/pull_page_names", "POST", "-b", "name=$&passcode=$", REQ_NAME, REQ_PASSCODE);
 
 	// pull array
 	int *array_length = malloc(sizeof(int));
@@ -222,7 +222,7 @@ void *data_read(void *meta_ptr) {
 
 	for (int read_body = start_read_body; read_body < end_read_body; read_body++) {
 		printf("id #%d: %s\n", read_body, array_body[read_body]);
-		res *wiki_page = send_req(ser_pt->sock_data, "/pull_data", "POST", "-q-b", "?name=$&passcode=$", REQ_NAME, REQ_PASSCODE, "unique_id=$", array_body[read_body]);
+		res *wiki_page = send_req(ser_pt->sock_data.runner, "/pull_data", "POST", "-b-t", "unique_id=$&name=$&passcode=$", array_body[read_body], REQ_NAME, REQ_PASSCODE, ser_pt->sock_data.mutex);
 
 		if (!wiki_page) { // socket close!
 			// reset socket:

--- a/serialize/vecrep.c
+++ b/serialize/vecrep.c
@@ -23,9 +23,6 @@
 #define DTF_THRESHOLD 0
 #define CLUSTER_THRESHOLD 2
 
-pthread_rwlock_t rwlock;
-pthread_rwlockattr_t attr;
-
 trie_t *fill_stopwords(char *stop_word_file) {
 	trie_t *trie = trie_create("-pc");
 
@@ -53,6 +50,7 @@ typedef struct SerializeObject {
 	int *array_length;
 
 	socket_t **sock_data;
+	pthread_rwlock_t *rwlock;
 
 	trie_t *stopword_trie;
 
@@ -67,7 +65,7 @@ typedef struct SerializeObject {
 } serialize_t;
 
 serialize_t *create_serializer(char **all_IDs, char **array_body, int *array_length,
-	socket_t **sock_data, trie_t *stopword_trie,
+	socket_t **sock_data, pthread_rwlock_t *rwlock, trie_t *stopword_trie,
 	mutex_t idf, mutex_t index_writer, mutex_t title_writer, int *doc_bag_length,
 	int start_read_body, int end_read_body) {
 
@@ -78,6 +76,7 @@ serialize_t *create_serializer(char **all_IDs, char **array_body, int *array_len
 	new_ser->array_length = array_length;
 
 	new_ser->sock_data = sock_data;
+	new_ser->rwlock = rwlock;
 
 	new_ser->stopword_trie = stopword_trie;
 
@@ -139,8 +138,11 @@ int main() {
 	/* e.g.:
 		socket, idf, index_writer, and title_writer
 	*/
+	pthread_rwlock_t *rwlock = malloc(sizeof(pthread_rwlock_t));
+	pthread_rwlockattr_t attr;
+
 	pthread_rwlockattr_setkind_np(&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
-	if (pthread_rwlock_init(&rwlock, &attr) != 0) {
+	if (pthread_rwlock_init(rwlock, &attr) != 0) {
 
 		printf("Bad sock lock\n");
 		exit(1);
@@ -154,7 +156,7 @@ int main() {
 
 	for (int thread_rip = 0; thread_rip < THREAD_NUMBER; thread_rip++) {
 		serialize_t *new_serializer = create_serializer(all_IDs, array_body, array_length, sock_sock,
-			stopword_trie, idf_mutex, index_writer_mutex,
+			rwlock, stopword_trie, idf_mutex, index_writer_mutex,
 			title_writer_mutex, doc_bag_length, thread_rip * doc_per_thread,
 			thread_rip == THREAD_NUMBER - 1 ? *array_length : (thread_rip + 1) * doc_per_thread);
 
@@ -245,8 +247,9 @@ void *data_read(void *meta_ptr) {
 	int end_read_body = ser_pt->end_read_body;
 
 	for (int read_body = start_read_body; read_body < end_read_body; read_body++) {
-		printf("lock %d %d\n", read_body, ser_pt->sock_data);
-		pthread_rwlock_wrlock(&rwlock);
+		printf("lock %d %d %d\n", read_body, ser_pt->sock_data, ser_pt->rwlock);
+		pthread_rwlock_wrlock(ser_pt->rwlock);
+		printf("locked %d\n", ser_pt->rwlock);
 
 		res *wiki_page = send_req(*(ser_pt->sock_data), "/pull_data", "POST", "-b", "unique_id=$&name=$&passcode=$", array_body[read_body], REQ_NAME, REQ_PASSCODE);
 		if (!wiki_page) { // socket close!
@@ -256,11 +259,11 @@ void *data_read(void *meta_ptr) {
 			*(ser_pt->sock_data) = get_socket(HOST, PORT);
 
 			// repeat data collection
-			pthread_rwlock_unlock(&rwlock);
+			pthread_rwlock_unlock(ser_pt->rwlock);
 			read_body--;
 			continue;
 		}
-		pthread_rwlock_unlock(&rwlock);
+		pthread_rwlock_unlock(ser_pt->rwlock);
 
 		// printf("CHECK: %s\n", res_body(wiki_page));
 		// parse the wiki data and write to the bag of words


### PR DESCRIPTION
This threading system allows for multiple documents to be read from the server and parsed concurrently, which results in faster run time speed for larger sums of documents. Currently, there is 1 socket per 2 threads, and the efficiency responds well with 8 total threads. The behind the scenes of how the multiple sockets are working is rather interesting, but does seem to work.

There are no issues with merging this branch and only improve the current main version. #2 can be closed based on this merge.